### PR TITLE
Issue #39: Fix logs persistence

### DIFF
--- a/deploy/prod/docker-compose.yaml
+++ b/deploy/prod/docker-compose.yaml
@@ -6,6 +6,6 @@ services:
     env_file:
       - .env
     environment:
-      - LOGS_FILENAME=var/log/wisdom-bot/nest-%DATE%.log
+      - LOGS_FILENAME=/var/log/wisdom-bot/nest-%DATE%.log
     volumes:
       - ./logs/tomcat:/var/log/wisdom-bot

--- a/deploy/prod/docker-compose.yaml
+++ b/deploy/prod/docker-compose.yaml
@@ -8,4 +8,4 @@ services:
     environment:
       - LOGS_FILENAME=/var/log/wisdom-bot/nest-%DATE%.log
     volumes:
-      - ./logs/tomcat:/var/log/wisdom-bot
+      - ./logs:/var/log/wisdom-bot


### PR DESCRIPTION
Cause: in the env var in the `docker-compose` file, `var` was used instead of `/var`, which created a `var` folder in the `app` folder instead of the actual linux `/var` folder.