### PR TITLE
Issue #37: Use submitDt quote year instead of current date quote year

### DIFF
--- a/src/domain/quotes/slash-interactions/receive-handler/receive-handler.service.ts
+++ b/src/domain/quotes/slash-interactions/receive-handler/receive-handler.service.ts
@@ -56,8 +56,7 @@ export class ReceiveHandlerService {
     const responseData: ReplyData = {
       ...randomQuote,
       receiverId: interaction.user.id,
-      year: new Date().getFullYear(),
-      // TODO retrieve author icon url
+      year: new Date(randomQuote.submitDt).getFullYear(),
 
       receiverIconUrl: (await interaction.user.displayAvatarURL()) || undefined,
       quoteAuthorIconUrl: (await author.displayAvatarURL()) || undefined,


### PR DESCRIPTION
Cause: We're using `Date().getFullYear()` which causes us to use the current year instead of the quote creation year