### PR TITLE
Adhoc #63: Improve build process

### DIFF
--- a/.github/actions/internal-version-string-generator/action.yml
+++ b/.github/actions/internal-version-string-generator/action.yml
@@ -1,0 +1,29 @@
+name: 'Internal version string generator'
+description: 'Generate different types of version strings for internal use'
+inputs:
+  pre-release-label:
+    description: The pre-release label
+    required: true
+outputs:
+  docker:
+    description: Version string for docker
+    value: ${{ inputs.pre-release-label }}-${{ steps.semver-parser.outputs.major }}.${{ steps.semver-parser.outputs.minor }}
+  app:
+    description: Version string to be displayed by the app during runtime
+    value: ${{ steps.package-version.outputs.current-version }}-${{ inputs.pre-release-label }}+${{ steps.commit.outputs.short }}
+runs:
+  using: composite
+  steps:
+    - name: Get version from package.json
+      id: package-version
+      uses: martinbeentjes/npm-get-version-action@main
+
+    - name: Parse semver string
+      id: semver-parser
+      uses: booxmedialtd/ws-action-parse-semver@v1
+      with:
+        input_string: ${{ steps.package-version.outputs.current-version }}
+
+    - name: Get HEAD commit hash
+      id: commit
+      uses: pr-mpt/actions-commit-hash@v2

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -10,9 +10,21 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v6
+
+      - name: Generate version strings
+        uses: './.github/actions/internal-version-string-generator'
+        id: version-generator
+        with:
+          pre-release-label: alpha
+      - name: 'Show generated strings'
+        run: |
+          echo Docker string: ${{ steps.version-generator.outputs.docker }}
+          echo App string: ${{ steps.version-generator.outputs.app }}
+      - name: package.json info
+        uses: jaywcjlove/github-action-package@main
+        with:
+          version: ${{ steps.version-generator.outputs.app }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -24,4 +36,4 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: jonfelixrico/wisdom-bot:${{steps.branch-name.outputs.current_branch}},jonfelixrico/wisdom-bot:alpha
+          tags: jonfelixrico/wisdom-bot:${{ steps.version-generator.outputs.docker }},jonfelixrico/wisdom-bot:alpha

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -3,7 +3,7 @@ name: Alpha pipeline
 on:
   push:
     branches:
-      - alpha-*
+      - develop-*
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wisdom-bot-v4",
-  "version": "3.1.2-SNAPSHOT",
+  "version": "3.1.2",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
* package.json versions no longer need to have `-SNAPSHOT` appended to it for non-release versions
* App version will show minor version and build SHA